### PR TITLE
fixed the behaviour of full_value() getter

### DIFF
--- a/src/easyscience/variable/parameter.py
+++ b/src/easyscience/variable/parameter.py
@@ -312,10 +312,6 @@ class Parameter(DescriptorNumber):
 
         :return: Value of self with unit and variance.
         """
-        if self._callback.fget is not None:
-            scalar = self._callback.fget()
-            if scalar != self._scalar:
-                self._scalar = scalar
         return self._scalar
 
     @full_value.setter

--- a/tests/unit_tests/variable/test_parameter.py
+++ b/tests/unit_tests/variable/test_parameter.py
@@ -635,6 +635,7 @@ class TestParameter:
         with pytest.raises(AttributeError):
             dependent_parameter.value = 3
 
+    @pytest.mark.skip(reason="No longer relevant")
     def test_full_value_match_callback(self, parameter: Parameter):
         # When
         self.mock_callback.fget.return_value = sc.scalar(1, unit='m')
@@ -642,7 +643,8 @@ class TestParameter:
         # Then Expect
         assert parameter.full_value == sc.scalar(1, unit='m')
         assert parameter._callback.fget.call_count == 1
-        
+
+    @pytest.mark.skip(reason="No longer relevant")
     def test_full_value_no_match_callback(self, parameter: Parameter):
         # When
         self.mock_callback.fget.return_value = sc.scalar(2, unit='m')


### PR DESCRIPTION
Fix for #143 full_value assignment fails when unit present

The callback can only return one type, and it does return the numerical value (see `value` property getter).
We assume the calculators only modify the actual parameter values, nothing else.

If this is not the case, we need to revisit the solution.