### PR TITLE
Pixi test

### DIFF
--- a/.github/actions/setup-pixi/action.yml
+++ b/.github/actions/setup-pixi/action.yml
@@ -1,0 +1,38 @@
+name: 'Setup Pixi Environment'
+description: 'Sets up pixi with common configuration'
+inputs:
+  environments:
+    description: 'Pixi environments to setup'
+    required: false
+    default: 'dev'
+  activate-environment:
+    description: 'Environment to activate'
+    required: false
+    default: 'dev'
+  run-install:
+    description: 'Whether to run install'
+    required: false
+    default: 'false'
+  cache:
+    description: 'Whether to use cache'
+    required: false
+    default: 'false'
+  post-cleanup:
+    description: 'Whether to run post cleanup'
+    required: false
+    default: 'false'
+  pixi-version:
+    description: 'Version of setup-pixi action to use'
+    required: false
+    default: 'v0.9.0'
+
+runs:
+  using: 'composite'
+  steps:
+    - uses: prefix-dev/setup-pixi@${{ inputs.pixi-version }}
+      with:
+        environments: ${{ inputs.environments }}
+        activate-environment: ${{ inputs.activate-environment }}
+        run-install: ${{ inputs.run-install }}
+        cache: ${{ inputs.cache }}
+        post-cleanup: ${{ inputs.post-cleanup }}

--- a/.github/actions/setup-pixi/action.yml
+++ b/.github/actions/setup-pixi/action.yml
@@ -25,7 +25,7 @@ inputs:
 runs:
   using: 'composite'
   steps:
-    - uses: prefix-dev/setup-pixi@0.9.0
+    - uses: prefix-dev/setup-pixi@v0.9.0
       with:
         environments: ${{ inputs.environments }}
         activate-environment: ${{ inputs.activate-environment }}

--- a/.github/actions/setup-pixi/action.yml
+++ b/.github/actions/setup-pixi/action.yml
@@ -12,7 +12,7 @@ inputs:
   run-install:
     description: 'Whether to run install'
     required: false
-    default: 'false'
+    default: 'true'
   cache:
     description: 'Whether to use cache'
     required: false
@@ -21,15 +21,11 @@ inputs:
     description: 'Whether to run post cleanup'
     required: false
     default: 'false'
-  pixi-version:
-    description: 'Version of setup-pixi action to use'
-    required: false
-    default: 'v0.9.0'
 
 runs:
   using: 'composite'
   steps:
-    - uses: prefix-dev/setup-pixi@${{ inputs.pixi-version }}
+    - uses: prefix-dev/setup-pixi@0.9.0
       with:
         environments: ${{ inputs.environments }}
         activate-environment: ${{ inputs.activate-environment }}

--- a/.github/workflows/documentation-build.yml
+++ b/.github/workflows/documentation-build.yml
@@ -27,13 +27,8 @@ jobs:
       with:
         fetch-depth: 0 # otherwise, you will failed to push refs to dest repo
         
-    - uses: prefix-dev/setup-pixi@v0.9.0
-      with:
-        environments: dev
-        activate-environment: dev
-        run-install: true
-        cache: false
-        post-cleanup: false
+    - name: Setup Pixi
+      uses: ./.github/actions/setup-pixi
 
     - name: Build documentation
       run: pixi run docs-build

--- a/.github/workflows/python-ci.yml
+++ b/.github/workflows/python-ci.yml
@@ -19,13 +19,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5
-      - uses: prefix-dev/setup-pixi@v0.9.0
-        with:
-          environments: dev
-          activate-environment: dev
-          run-install: false
-          cache: false
-          post-cleanup: false
+      - name: Setup Pixi
+        uses: ./.github/actions/setup-pixi
       - name: Run linting
         run: pixi run lint
       - name: Suggestion to fix issues
@@ -47,13 +42,8 @@ jobs:
     steps:
     - uses: actions/checkout@v5
 
-    - uses: prefix-dev/setup-pixi@v0.9.0
-      with:
-        environments: dev
-        activate-environment: dev
-        run-install: false
-        cache: false
-        post-cleanup: false
+    - name: Setup Pixi
+      uses: ./.github/actions/setup-pixi
 
     - name: Set Python version
       run: pixi add python=${{ matrix.python-version }}
@@ -79,13 +69,8 @@ jobs:
     steps:
     - uses: actions/checkout@v5
 
-    - uses: prefix-dev/setup-pixi@v0.9.0
-      with:
-        environments: dev
-        activate-environment: dev
-        run-install: false
-        cache: false
-        post-cleanup: false
+    - name: Setup Pixi
+      uses: ./.github/actions/setup-pixi
 
     - name: Build package
       run: pixi run build

--- a/.github/workflows/python-ci.yml
+++ b/.github/workflows/python-ci.yml
@@ -43,9 +43,11 @@ jobs:
     - uses: actions/checkout@v5
 
     - name: Setup Pixi
-      uses: ./.github/actions/setup-pixi
+      uses: prefix-dev/setup-pixi@v0.9.0
       with:
-        run-install: 'false'
+        run-install: false
+        cache: false
+        post-cleanup: false
 
     - name: Set Python version
       run: pixi add python=${{ matrix.python-version }}

--- a/.github/workflows/python-ci.yml
+++ b/.github/workflows/python-ci.yml
@@ -44,12 +44,14 @@ jobs:
 
     - name: Setup Pixi
       uses: ./.github/actions/setup-pixi
+      with:
+        run-install: 'false'
 
     - name: Set Python version
       run: pixi add python=${{ matrix.python-version }}
 
     - name: Install dependencies and run tests
-      run: pixi run test
+      run: pixi run -e dev test
 
     - name: Upload coverage
       uses: codecov/codecov-action@v4.0.1

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -26,13 +26,8 @@ jobs:
     steps:
     - uses: actions/checkout@v5
 
-    - uses: prefix-dev/setup-pixi@v0.9.0
-      with:
-        environments: dev
-        activate-environment: dev
-        run-install: true
-        cache: false
-        post-cleanup: false
+    - name: Setup Pixi
+      uses: ./.github/actions/setup-pixi
 
     - name: Build package
       run: pixi run build


### PR DESCRIPTION
Use local actions to simplify pixi setup

Use of `uses: prefix-dev/setup-pixi@v0.9.0` in the Code_Testing job is necessary since we need an `activate-environment:`-less specs for it here. The subsequent `pixi add python=${{ matrix.python-version }}` will create and activate the required env instead 
