### PR TITLE
Updated composite actions

### DIFF
--- a/.github/workflows/documentation-build.yml
+++ b/.github/workflows/documentation-build.yml
@@ -31,7 +31,7 @@ jobs:
         fetch-depth: 0 # otherwise, you will failed to push refs to dest repo
         
     - name: Setup Pixi
-      uses: ./.github/actions/setup-pixi
+      uses: easyscience/github/.github/actions/setup-pixi@main
 
     - name: Build documentation
       run: pixi run --environment dev docs-build

--- a/.github/workflows/documentation-build.yml
+++ b/.github/workflows/documentation-build.yml
@@ -31,7 +31,7 @@ jobs:
         fetch-depth: 0 # otherwise, you will failed to push refs to dest repo
         
     - name: Setup Pixi
-      uses: easyscience/github/.github/actions/setup-pixi@master
+      uses: easyscience/actions/pixi@master
 
     - name: Build documentation
       run: pixi run --environment dev docs-build

--- a/.github/workflows/documentation-build.yml
+++ b/.github/workflows/documentation-build.yml
@@ -31,7 +31,7 @@ jobs:
         fetch-depth: 0 # otherwise, you will failed to push refs to dest repo
         
     - name: Setup Pixi
-      uses: easyscience/github/.github/actions/setup-pixi@main
+      uses: easyscience/github/.github/actions/setup-pixi@master
 
     - name: Build documentation
       run: pixi run --environment dev docs-build

--- a/.github/workflows/nightly-check.yml
+++ b/.github/workflows/nightly-check.yml
@@ -12,7 +12,7 @@ jobs:
     - uses: actions/checkout@v5
 
     - name: Setup Pixi
-      uses: easyscience/github/.github/actions/setup-pixi@master
+      uses: easyscience/actions/pixi@master
 
     - name: Update lock file
       run: pixi run update-lock

--- a/.github/workflows/nightly-check.yml
+++ b/.github/workflows/nightly-check.yml
@@ -12,7 +12,7 @@ jobs:
     - uses: actions/checkout@v5
 
     - name: Setup Pixi
-      uses: ./.github/actions/setup-pixi
+      uses: easyscience/github/.github/actions/setup-pixi@main
 
     - name: Update lock file
       run: pixi run update-lock

--- a/.github/workflows/nightly-check.yml
+++ b/.github/workflows/nightly-check.yml
@@ -12,7 +12,7 @@ jobs:
     - uses: actions/checkout@v5
 
     - name: Setup Pixi
-      uses: easyscience/github/.github/actions/setup-pixi@main
+      uses: easyscience/github/.github/actions/setup-pixi@master
 
     - name: Update lock file
       run: pixi run update-lock

--- a/.github/workflows/python-ci.yml
+++ b/.github/workflows/python-ci.yml
@@ -20,7 +20,7 @@ jobs:
     steps:
       - uses: actions/checkout@v5
       - name: Setup Pixi
-        uses: easyscience/github/.github/actions/setup-pixi@main
+        uses: easyscience/github/.github/actions/setup-pixi@master
       - name: Run linting
         run: pixi run lint
 
@@ -85,7 +85,7 @@ jobs:
     - uses: actions/checkout@v5
 
     - name: Setup Pixi
-      uses: easyscience/github/.github/actions/setup-pixi@main
+      uses: easyscience/github/.github/actions/setup-pixi@master
 
     - name: Build package
       run: pixi run build

--- a/.github/workflows/python-ci.yml
+++ b/.github/workflows/python-ci.yml
@@ -20,7 +20,7 @@ jobs:
     steps:
       - uses: actions/checkout@v5
       - name: Setup Pixi
-        uses: easyscience/github/.github/actions/setup-pixi@master
+        uses: easyscience/actions/pixi@master
       - name: Run linting
         run: pixi run lint
 
@@ -85,7 +85,7 @@ jobs:
     - uses: actions/checkout@v5
 
     - name: Setup Pixi
-      uses: easyscience/github/.github/actions/setup-pixi@master
+      uses: easyscience/actions/pixi@master
 
     - name: Build package
       run: pixi run build

--- a/.github/workflows/python-ci.yml
+++ b/.github/workflows/python-ci.yml
@@ -20,7 +20,7 @@ jobs:
     steps:
       - uses: actions/checkout@v5
       - name: Setup Pixi
-        uses: ./.github/actions/setup-pixi
+        uses: easyscience/github/.github/actions/setup-pixi@main
       - name: Run linting
         run: pixi run lint
 
@@ -85,7 +85,7 @@ jobs:
     - uses: actions/checkout@v5
 
     - name: Setup Pixi
-      uses: ./.github/actions/setup-pixi
+      uses: easyscience/github/.github/actions/setup-pixi@main
 
     - name: Build package
       run: pixi run build

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -28,7 +28,7 @@ jobs:
     - uses: actions/checkout@v5
     
     - name: Setup Pixi
-      uses: easyscience/github/.github/actions/setup-pixi@main
+      uses: easyscience/github/.github/actions/setup-pixi@master
         
     - name: Set Python version
       run: pixi add python=${{ matrix.python-version }}

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -28,7 +28,7 @@ jobs:
     - uses: actions/checkout@v5
     
     - name: Setup Pixi
-      uses: easyscience/github/.github/actions/setup-pixi@master
+      uses: easyscience/actions/pixi@master
         
     - name: Set Python version
       run: pixi add python=${{ matrix.python-version }}

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -28,7 +28,7 @@ jobs:
     - uses: actions/checkout@v5
     
     - name: Setup Pixi
-      uses: ./.github/actions/setup-pixi
+      uses: easyscience/github/.github/actions/setup-pixi@main
         
     - name: Set Python version
       run: pixi add python=${{ matrix.python-version }}

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -27,7 +27,7 @@ jobs:
     - uses: actions/checkout@v5
 
     - name: Setup Pixi
-      uses: ./.github/actions/setup-pixi
+      uses: easyscience/github/.github/actions/setup-pixi@main
 
     - name: Build package
       run: pixi run build

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -27,7 +27,7 @@ jobs:
     - uses: actions/checkout@v5
 
     - name: Setup Pixi
-      uses: easyscience/github/.github/actions/setup-pixi@main
+      uses: easyscience/github/.github/actions/setup-pixi@master
 
     - name: Build package
       run: pixi run build

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -27,7 +27,7 @@ jobs:
     - uses: actions/checkout@v5
 
     - name: Setup Pixi
-      uses: easyscience/github/.github/actions/setup-pixi@master
+      uses: easyscience/actions/pixi@master
 
     - name: Build package
       run: pixi run build


### PR DESCRIPTION
Moved the pixi install action to a central repo in the `actions` project.

Should be helpful for projects inheriting this and other, related actions.