### PR TITLE
Reordered operations in Map.add_vertex

### DIFF
--- a/src/easyscience/global_object/map.py
+++ b/src/easyscience/global_object/map.py
@@ -143,10 +143,13 @@ class Map:
         # but the finalizer hasn't run yet
         if name in self.__type_dict:
             del self.__type_dict[name]
+
         self._store[name] = obj
-        self.__type_dict[name] = _EntryList()  # Add objects type to the list of types
-        self.__type_dict[name].finalizer = weakref.finalize(self._store[name], self.prune, name)
-        self.__type_dict[name].type = obj_type
+
+        entry_list = _EntryList()
+        entry_list.finalizer = weakref.finalize(obj, self.prune, name)
+        entry_list.type = obj_type
+        self.__type_dict[name] = entry_list  # Add objects type to the list of types
 
     def add_edge(self, start_obj: object, end_obj: object):
         if start_obj.unique_name in self.__type_dict:


### PR DESCRIPTION
Fix is made to avoid hitting a race condition due to weakref.finalize() being called. It seems that .finalize temporarily deletes references of the object passed to it from dicts, therefore trying to get it from __type_dict or _store might randomly raise a KeyError.

This PR fixes failing tests from https://github.com/easyscience/dynamics-lib/pull/96